### PR TITLE
Delete temp file after verify exits

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -84,6 +84,7 @@ async function main()
 
 	kb.on('close', code =>
 	{
+		fs.unlinkSync(tmpfile);
 		process.exit(code);
 	});
 }


### PR DESCRIPTION
This is an awesome tool @ceejbot 

### What I did 
- Added `fs.unlink(tmpfile);` to the close `child_process` event.

The file isn't that big but wasn't sure if it was necessary to keep around after keybase used it.